### PR TITLE
Integrate power measurements in NITROS monitor node

### DIFF
--- a/isaac_ros_benchmark/src/nitros_monitor_node.cpp
+++ b/isaac_ros_benchmark/src/nitros_monitor_node.cpp
@@ -124,6 +124,11 @@ void NitrosMonitorNode::CreateROSTypeMonitorSubscriber()
     get_logger(),
     "[NitrosMonitorNode] Created a ROS type monitor subscriber: topic=\"%s\"",
     monitor_sub_->get_topic_name());
+
+  if (monitor_power_data_format_ == "power_msgs/msg/Power")
+  { 
+    CreatePowerSubscription();
+  }
 }
 
 void NitrosMonitorNode::CreateNitrosMonitorSubscriber()
@@ -159,6 +164,12 @@ void NitrosMonitorNode::CreateNitrosMonitorSubscriber()
     get_logger(),
     "[NitrosMonitorNode] Created an NITROS type monitor subscriber: topic=\"%s\"",
     monitor_sub_->get_topic_name());
+
+  if (monitor_power_data_format_ == "power_msgs/msg/Power")
+  { 
+    CreatePowerSubscription();
+  }
+
 }
 
 template<typename T>


### PR DESCRIPTION
Add subscription to `/power` topic for all the subscription methods in the `NitrosMonitorNode`.

Depends on https://github.com/robotperf/ros2_benchmark/pull/6.